### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/cfn/master-region.json
+++ b/cfn/master-region.json
@@ -103,7 +103,7 @@
         },
         "Handler": "lambda_function.lambda_handler",
         "Role": { "Fn::GetAtt": ["JITRLambdaRole", "Arn"] },
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
         "MemorySize" : 256,
         "Timeout": "30",
         "TracingConfig": {"Mode": "Active"}

--- a/cfn/slave-region.json
+++ b/cfn/slave-region.json
@@ -97,7 +97,7 @@
         },
         "Handler": "lambda_function.lambda_handler",
         "Role": { "Fn::GetAtt": ["JITRLambdaRole", "Arn"] },
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
         "MemorySize" : 256,
         "Timeout": "30",
         "TracingConfig": {"Mode": "Active"}
@@ -124,7 +124,7 @@
           },
           "Handler": "lambda_function.lambda_handler",
           "Role": { "Fn::GetAtt": ["SFNLambdaRole", "Arn"] },
-          "Runtime": "python3.7",
+          "Runtime": "python3.10",
           "MemorySize" : 256,
           "Timeout": "30",
           "TracingConfig": {"Mode": "Active"}
@@ -322,7 +322,7 @@
         },
         "Handler": "lambda_function.lambda_handler",
         "Role": { "Fn::GetAtt": ["SFNLambdaRole", "Arn"] },
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
         "MemorySize" : 256,
         "Timeout": "30",
         "TracingConfig": {"Mode": "Active"}
@@ -338,7 +338,7 @@
         },
         "Handler": "lambda_function.lambda_handler",
         "Role": { "Fn::GetAtt": ["SFNLambdaRole", "Arn"] },
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
         "MemorySize" : 256,
         "Timeout": "30",
         "TracingConfig": {"Mode": "Active"}
@@ -354,7 +354,7 @@
         },
         "Handler": "lambda_function.lambda_handler",
         "Role": { "Fn::GetAtt": ["SFNLambdaRole", "Arn"] },
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
         "MemorySize" : 256,
         "Timeout": "30",
         "TracingConfig": {"Mode": "Active"}


### PR DESCRIPTION
CloudFormation templates in reinvent2019-iot335-code have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.